### PR TITLE
initial checkin of swagger docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,11 @@ help:
 ############################################################################
 #= SETUP, INSTALLATION, PACKAGING
 
-#=> venv: make a Python 3 virtual environment
+#=> venv: make a Python 2 (for now) virtual environment
 .PHONY: venv
 venv:
-	pyvenv venv; \
+	virtualenv -p python2 venv; \
 	source venv/bin/activate; \
-	python -m ensurepip --upgrade; \
 	pip install --upgrade pip setuptools
 
 #=> setup: setup/upgrade packages *in current environment*

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,16 @@
-hgvs-eval 
+hgvs-eval
 !!!!!!!!!
 
-Automated evaluation suite to assess tools that manipulate HGVS formatted variants
+Automated evaluation suite to assess tools that manipulate HGVS formatted variants.
 
 
-Developers installation instructions::
+Developer installation instructions::
 
   > virtualenv hgvseval-ve
   > source hgvseval-ve/bin/activate
   > git clone https://github.com/biocommons/hgvs-eval.git
   > cd hgvs-eval
-  > make setup 
+  > make setup
   > make develop
 
 
@@ -21,10 +21,15 @@ Launch REST service for biocommons/hgvs::
 
 Test the endpoint::
 
-   curl \
-   -d hgvs_string="NC_000020.10:g.278701_278703delGGC" \
-   -d ac=NM_033089.6  \
-   http://0.0.0.0:8000/project_g_to_t
+  $ curl \
+  -d hgvs_string="NC_000020.10:g.278701_278703delGGC" \
+  -d ac=NM_033089.6  \
+  http://0.0.0.0:8000/project_g_to_t
+
+
+Run the test suite, output to HTML and JSON::
+
+  $ hgvs-eval --html report.html --json report.json http://0.0.0.0:8000/
 
 
 ----

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,28 @@ hgvs-eval
 
 Automated evaluation suite to assess tools that manipulate HGVS formatted variants
 
+
+Developers installation instructions::
+
+  > virtualenv hgvseval-ve
+  > source hgvseval-ve/bin/activate
+  > git clone https://github.com/biocommons/hgvs-eval.git
+  > cd hgvs-eval
+  > make setup 
+  > make develop
+
+
+Launch REST service for biocommons/hgvs::
+
+  > python app.py
+
+
+Test the endpoint::
+
+   curl \
+   -d hgvs_string="NC_000020.10:g.278701_278703delGGC" \
+   -d ac=NM_033089.6  \
+   http://0.0.0.0:8000/project_g_to_t
+
+
 ----
-
-
-

--- a/README.rst
+++ b/README.rst
@@ -1,35 +1,83 @@
 hgvs-eval
 !!!!!!!!!
 
-Automated evaluation suite to assess tools that manipulate HGVS formatted variants.
+*Automated evaluation suite to assess tools that manipulate
+HGVS-formatted variants.*
 
 
-Developer installation instructions::
+Overview
+@@@@@@@@
 
-  > virtualenv hgvseval-ve
-  > source hgvseval-ve/bin/activate
-  > git clone https://github.com/biocommons/hgvs-eval.git
-  > cd hgvs-eval
-  > make setup
-  > make develop
-
-
-Launch REST service for biocommons/hgvs::
-
-  > python app.py
+The hgvs-eval package provides an objective set of tests to evaluate
+features provided by tools that manipulate HGVS-formatted variants.
+The package envisions two users: 1) tool users who wish to identify a
+tool for their use case; and 2) developers who would like additional
+function tests.
 
 
-Test the endpoint::
+It assesses the following features:
 
-  $ curl \
-  -d hgvs_string="NC_000020.10:g.278701_278703delGGC" \
-  -d ac=NM_033089.6  \
-  http://0.0.0.0:8000/project_g_to_t
+* Transcript source: NCBI/RefSeq, ENST, LRG
+
+* Variant types: SNV, MNV, del, ins, delins
+
+* Validation and Parsing: 
+
+* Sequence Projections: Converting g. ⟺ c., g. ⟺ n., c. ⟹ p.
+
+* Special cases: A few special features are assessed, including:
+
+  * Correct projection in the presence of genome-transcript indels
+  * Frameshifts include predicted distance to termination
 
 
-Run the test suite, output to HTML and JSON::
+
+Components
+@@@@@@@@@@
+
+* Test definitions -- a TSV file with inputs and expected output
+* Test server -- the REST service that wraps the package being tested
+* Test client -- runs tests (from test definitions) against the test server
+
+This package currently includes all three components.
+
+The test client is written in Python.
+
+A test server may be written in any language appropriate for the
+package being tested.
+
+**TODO::** Write up REST interface specs as rst for inclusion in repo.
+
+
+Quick start
+@@@@@@@@@@@
+
+These instructions assume that the client and server use the same
+virtual environment.  The client and server may use different virtual
+environments, or even different languages.
+
+Download the package and prepare your environment::
+
+  $ git clone https://github.com/biocommons/hgvs-eval.git
+  $ cd hgvs-eval
+  $ make devready
+  $ source venv/bin/activate
+
+If you have local instances of UTA and seqrepo, enable them with::
+
+  (values will depend on your setup)
+  $ export UTA_DB_URL=postgresql://anonymous@localhost/uta_dev/uta_20160908
+  $ export HGVS_SEQREPO_DIR=/usr/local/share/seqrepo/20161024
+
+Launch the REST service for biocommons/hgvs::
+
+  $ python app.py &
+
+A quick test::
+
+  $ curl -d hgvs_string="NC_000020.10:g.278701_278703delGGC" -d ac=NM_033089.6  http://0.0.0.0:8000/project_g_to_t
+
+Run the test suite (client), with output to HTML and JSON::
 
   $ hgvs-eval --html report.html --json report.json http://0.0.0.0:8000/
 
-
-----

--- a/etc/develop.reqs
+++ b/etc/develop.reqs
@@ -2,6 +2,4 @@ flake8
 ipython
 pytest
 pytest-cov
-tox
 yapf
-hgvs>=0.5.0.dev

--- a/etc/develop.reqs
+++ b/etc/develop.reqs
@@ -4,3 +4,4 @@ pytest
 pytest-cov
 tox
 yapf
+hgvs>=0.5.0.dev

--- a/etc/install.reqs
+++ b/etc/install.reqs
@@ -4,3 +4,4 @@ pytest-html
 flask
 requests
 protobuf
+flask-cors

--- a/etc/install.reqs
+++ b/etc/install.reqs
@@ -4,4 +4,6 @@ pytest-html
 flask
 requests
 protobuf
+pysam
+biocommons.seqrepo
 hgvs>=0.5.0.dev

--- a/etc/install.reqs
+++ b/etc/install.reqs
@@ -4,3 +4,4 @@ pytest-html
 flask
 requests
 protobuf
+hgvs>=0.5.0.dev

--- a/hgvseval/cli.py
+++ b/hgvseval/cli.py
@@ -20,12 +20,13 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '--html',
         help='Set the HTML output filename',
-        default='report.html'
+        default=None
     )
-    # parser.add_argument(
-    #     '--dir',
-    #     help='Set the local tests directory'
-    # )
+    parser.add_argument(
+        '--json',
+        help='Set the JSON output filename',
+        default=None
+    )
     parser.add_argument("endpoint")
     args = parser.parse_args(argv)
 
@@ -37,12 +38,20 @@ def main(argv=sys.argv[1:]):
 
     test_args = [
         "--endpoint={}".format(args.endpoint),
-        "--html={}".format(args.html),
-        # --json={}
-        "--self-contained-html",
         "--capture=no",
         test_dir,
     ]
+
+    if args.html:
+        test_args += [
+            "--html={}".format(args.html),
+            "--self-contained-html"
+        ]
+
+    if args.json:
+        test_args += [
+            "--json={}".format(args.json),
+        ]
 
     pytest.main(test_args, plugins=[])
 

--- a/hgvseval/messages.proto
+++ b/hgvseval/messages.proto
@@ -2,6 +2,7 @@
 
 syntax = "proto3";
 package ga4gh;
+import "google/api/annotations.proto";
 
 message HGVSInfoRequest { }
 message HGVSInfoResponse {
@@ -36,13 +37,54 @@ message HGVSProjectionRequest {
   string ac = 2;
 }
 
+// coordinate with @app.route statements in app.py
 service HGVSProjectionService {
   rpc GetHGVSInfo(HGVSInfoRequest)
-      returns (HGVSInfoResponse) ;
+      returns (HGVSInfoResponse) {
+        option (google.api.http) = {
+          get: "/info"
+        };
+  };
   rpc GetHGVSValidation(HGVSProjectionRequest)
-      returns (HGVSProjectionResponse);
+      returns (HGVSProjectionResponse) {
+        option (google.api.http) = {
+          post: "/validate"
+          body: "*"
+        };
+  };
   rpc GetHGVSParse(HGVSParseRequest)
-      returns (HGVSParseResponse);
+      returns (HGVSParseResponse) {
+        option (google.api.http) = {
+          post: "/parse"
+          body: "*"
+        };
+  };
   rpc GetHGVSRewrite(HGVSProjectionRequest)
-      returns (HGVSProjectionResponse);
+      returns (HGVSProjectionResponse) {
+        option (google.api.http) = {
+          post: "/rewrite"
+          body: "*"
+        };
+  };
+  rpc ProjectGToT(HGVSProjectionRequest)
+      returns (HGVSProjectionResponse) {
+        option (google.api.http) = {
+          post: "/project_g_to_t"
+          body: "*"
+        };
+  };
+  rpc ProjectTToG(HGVSProjectionRequest)
+      returns (HGVSProjectionResponse) {
+        option (google.api.http) = {
+          post: "/project_t_to_g"
+          body: "*"
+        };
+  };
+  rpc ProjectCToP(HGVSProjectionRequest)
+      returns (HGVSProjectionResponse) {
+        option (google.api.http) = {
+          post: "/project_c_to_p"
+          body: "*"
+        };
+  };
 }

--- a/hgvseval/testservice/biocommonsService.py
+++ b/hgvseval/testservice/biocommonsService.py
@@ -1,5 +1,5 @@
 import hgvseval
-from interface import HGVSTestService
+from .interface import HGVSTestService
 
 import hgvs.dataproviders.uta
 import hgvs.parser

--- a/messages.swagger.json
+++ b/messages.swagger.json
@@ -1,0 +1,281 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "messages.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "operationId": "GetHGVSInfo",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSInfoResponse"
+            }
+          }
+        },
+        "tags": [
+          "HGVSProjectionService"
+        ]
+      }
+    },
+    "/parse": {
+      "post": {
+        "operationId": "GetHGVSParse",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSParseResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSParseRequest"
+            }
+          }
+        ],
+        "tags": [
+          "HGVSProjectionService"
+        ]
+      }
+    },
+    "/project_c_to_p": {
+      "post": {
+        "operationId": "ProjectCToP",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "HGVSProjectionService"
+        ]
+      }
+    },
+    "/project_g_to_t": {
+      "post": {
+        "operationId": "ProjectGToT",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "HGVSProjectionService"
+        ]
+      }
+    },
+    "/project_t_to_g": {
+      "post": {
+        "operationId": "ProjectTToG",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "HGVSProjectionService"
+        ]
+      }
+    },
+    "/rewrite": {
+      "post": {
+        "operationId": "GetHGVSRewrite",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "HGVSProjectionService"
+        ]
+      }
+    },
+    "/validate": {
+      "post": {
+        "operationId": "GetHGVSValidation",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghHGVSProjectionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "HGVSProjectionService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ga4ghHGVSInfoRequest": {
+      "type": "object"
+    },
+    "ga4ghHGVSInfoResponse": {
+      "type": "object",
+      "properties": {
+        "eval_version": {
+          "type": "string",
+          "format": "string"
+        },
+        "nomenclature_version": {
+          "type": "string",
+          "format": "string"
+        },
+        "package_version": {
+          "type": "string",
+          "format": "string"
+        },
+        "rest_api_version": {
+          "type": "string",
+          "format": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "ga4ghHGVSParseRequest": {
+      "type": "object",
+      "properties": {
+        "hgvs_string": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "ga4ghHGVSParseResponse": {
+      "type": "object",
+      "properties": {
+        "ac": {
+          "type": "string",
+          "format": "string"
+        },
+        "alt": {
+          "type": "string",
+          "format": "string"
+        },
+        "pos": {
+          "$ref": "#/definitions/ga4ghPos"
+        }
+      }
+    },
+    "ga4ghHGVSProjectionRequest": {
+      "type": "object",
+      "properties": {
+        "ac": {
+          "type": "string",
+          "format": "string"
+        },
+        "hgvs_string": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "ga4ghHGVSProjectionResponse": {
+      "type": "object",
+      "properties": {
+        "hgvs_string": {
+          "type": "string",
+          "format": "string"
+        }
+      }
+    },
+    "ga4ghPos": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string",
+          "format": "int64"
+        },
+        "start": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    }
+  }
+}

--- a/scripts/make-swagger.sh
+++ b/scripts/make-swagger.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# generate swagger documentation from protobuf using grpc support
+# setup: see https://github.com/grpc-ecosystem/grpc-gateway#usage
+
+protoc -I/usr/local/include -I.  -I$GOPATH/src  \
+  -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
+  -I../hgvseval  \
+  --swagger_out=logtostderr=true:../ ../hgvseval/messages.proto

--- a/scripts/server-swagger.sh
+++ b/scripts/server-swagger.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# run swagger UI from docker container
+# setup: install docker, instantiate hgvs server and express here.
+
+# parameter: $1 = complete url of swagger json [http://192.168.99.100:8000/api]
+if [ $# -eq 0 ]
+  then
+    echo "Please pass URL of HGVS swagger endpoint"
+    exit 1;
+fi
+
+docker run -d --name swagger-ui -p 8888:8888 -e "API_URL=$1" sjeandeaux/docker-swagger-ui

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
-package_name = "biocommons.pkg"
+package_name = "hgvseval"
 short_description = open("doc/short_description.txt").read()
 long_description = open("README.rst").read()
 

--- a/setup.py
+++ b/setup.py
@@ -51,24 +51,29 @@ setup(
 
     install_requires = [
         "flask",
+        "protobuf",
+        "requests",
         "six",
-    ],
 
-    setup_requires = [
+        # Given the way we're using pytest, these belong in
+        # install_requires (usually in setup_requires and
+        # tests_require)
         "pytest",
         "pytest-runner",
         "pytest-json",
         "pytest-html",
+
+        # hgvs -- should probably move to extras_require eventually
+        "hgvs>=0.5dev",
+        "biocommons.seqrepo",
+    ],
+
+    setup_requires = [
         "setuptools_scm",
-        "requests",
-        "protobuf",
         "wheel",
     ],
 
     tests_require = [
-        "pytest",
-        "pytest-cov",
-        "tox",
     ],
 )
 


### PR DESCRIPTION
This PR has 1 new feature: swagger docs closes #7 
- `scripts/make-swagger.sh` - generates the file /messages.swagger.json ( has a development time dependency on [grpc](https://github.com/grpc-ecosystem/grpc-gateway#usage) )
- `/api` - app.py has a new endpoint  to serves  messages.swagger.json 
- `scripts/server-swagger.sh` - brings up a docker image to explore the swagger ui

e.g.

![image](https://cloud.githubusercontent.com/assets/47808/19495041/9180d924-9536-11e6-9f9c-80eaa848ad83.png)
